### PR TITLE
Fixed spelling mistake in general.cs

### DIFF
--- a/BotHATTwaffle2/src/Models/JSON/general.cs
+++ b/BotHATTwaffle2/src/Models/JSON/general.cs
@@ -27,6 +27,6 @@ namespace BotHATTwaffle2
 
         [DefaultValue("competitive_level_testing")]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
-        public string compeitiveTestingChannel { get; set; }
+        public string competitiveTestingChannel { get; set; }
     }
 }


### PR DESCRIPTION
compeitiveTestingChannel => competitiveTestingChannel