### PR TITLE
CoreRCON added - Source RCON Library removed.

### DIFF
--- a/BotHATTwaffle2.sln
+++ b/BotHATTwaffle2.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 16.0.29001.49
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BotHATTwaffle2", "BotHATTwaffle2\BotHATTwaffle2.csproj", "{A421C86F-A0C1-4A02-8EBF-772AFC5C25B0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RCONServerLib", "RCONServerLib\RCONServerLib.csproj", "{2EFA0311-14CE-414B-9867-FC0D1FF6F6C4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CoreRCON", "CoreRCON\CoreRCON.csproj", "{4ADEAD8F-818B-4061-A906-A3F5F7B2FDA5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -17,10 +17,10 @@ Global
 		{A421C86F-A0C1-4A02-8EBF-772AFC5C25B0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A421C86F-A0C1-4A02-8EBF-772AFC5C25B0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A421C86F-A0C1-4A02-8EBF-772AFC5C25B0}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2EFA0311-14CE-414B-9867-FC0D1FF6F6C4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{2EFA0311-14CE-414B-9867-FC0D1FF6F6C4}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2EFA0311-14CE-414B-9867-FC0D1FF6F6C4}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{2EFA0311-14CE-414B-9867-FC0D1FF6F6C4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4ADEAD8F-818B-4061-A906-A3F5F7B2FDA5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4ADEAD8F-818B-4061-A906-A3F5F7B2FDA5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4ADEAD8F-818B-4061-A906-A3F5F7B2FDA5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4ADEAD8F-818B-4061-A906-A3F5F7B2FDA5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/BotHATTwaffle2.sln.DotSettings
+++ b/BotHATTwaffle2.sln.DotSettings
@@ -76,4 +76,5 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unmuting/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=unpause/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unpausing/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=voiceenable/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=voiceenable/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Webhook/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/BotHATTwaffle2/BotHATTwaffle2.csproj
+++ b/BotHATTwaffle2/BotHATTwaffle2.csproj
@@ -26,7 +26,7 @@
 </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\RCONServerLib\RCONServerLib.csproj" />
+    <ProjectReference Include="..\CoreRCON\CoreRCON.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BotHATTwaffle2/src/Models/JSON/ProgramSettings.cs
+++ b/BotHATTwaffle2/src/Models/JSON/ProgramSettings.cs
@@ -14,5 +14,6 @@ namespace BotHATTwaffle2
         public string ImgurApi { get; set; }
         public string PlaytestDemoPath { get; set; }
         public string SteamworksAPI { get; set; }
+        public ushort ListenPort { get; set; }
     }
 }

--- a/BotHATTwaffle2/src/Models/JSON/lists.cs
+++ b/BotHATTwaffle2/src/Models/JSON/lists.cs
@@ -9,5 +9,6 @@ namespace BotHATTwaffle2
         public List<string> Roles { get; set; }
         public List<string> Playing { get; set; }
         public List<string> PublicCommands { get; set; }
+        public List<string> SteamIDs { get; set; }
     }
 }

--- a/BotHATTwaffle2/src/Models/LiteDB/Server.cs
+++ b/BotHATTwaffle2/src/Models/LiteDB/Server.cs
@@ -1,6 +1,6 @@
 ﻿namespace BotHATTwaffle2.Models.LiteDB
 {
-    class Server
+    public class Server
     {
         public int Id { get; set; }
         public string ServerId { get; set; }

--- a/BotHATTwaffle2/src/Program.cs
+++ b/BotHATTwaffle2/src/Program.cs
@@ -4,6 +4,7 @@ using BotHATTwaffle2.Handlers;
 using BotHATTwaffle2.Services;
 using BotHATTwaffle2.Services.Calendar;
 using BotHATTwaffle2.Services.Playtesting;
+using BotHATTwaffle2.Services.SRCDS;
 using BotHATTwaffle2.Services.YouTube;
 using BotHATTwaffle2.Util;
 using Discord;
@@ -26,8 +27,14 @@ namespace BotHATTwaffle2
         {
             Console.Title = "Bot Ido";
 
+            //Always download users to make sure we can always get them
+            var config = new DiscordSocketConfig
+            {
+                AlwaysDownloadUsers = true
+            };
+
             // Dependency injection. All objects use constructor injection.
-            _client = new DiscordSocketClient();
+            _client = new DiscordSocketClient(config);
             _commands = new CommandService();
             _services = new ServiceCollection()
                 .AddSingleton(_client)
@@ -43,6 +50,8 @@ namespace BotHATTwaffle2
                 .AddSingleton<YouTube>()
                 .AddSingleton<ReservationService>()
                 .AddSingleton<PlaytestService>()
+                .AddSingleton<RconService>()
+                .AddSingleton<LogReceiverService>()
                 .AddSingleton<IHelpService, HelpService>()
                 .AddSingleton(s => new InteractiveService(_client, TimeSpan.FromMinutes(5)))
                 .BuildServiceProvider();

--- a/BotHATTwaffle2/src/Services/Calendar/GoogleCalendar.cs
+++ b/BotHATTwaffle2/src/Services/Calendar/GoogleCalendar.cs
@@ -145,7 +145,7 @@ namespace BotHATTwaffle2.Services.Calendar
             _testEvent.EndDateTime = eventItem.End.DateTime;
 
             //Creators
-            _testEvent.Creators = _dataService.GetSocketUser(description.ElementAtOrDefault(0), ',');
+            _testEvent.Creators = _dataService.GetSocketUsers(description.ElementAtOrDefault(0), ',');
 
             //Imgur Album
             _testEvent.ImageGallery = GeneralUtil.ValidateUri(description.ElementAtOrDefault(1));

--- a/BotHATTwaffle2/src/Services/Playtesting/KickUserRcon.cs
+++ b/BotHATTwaffle2/src/Services/Playtesting/KickUserRcon.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using BotHATTwaffle2.Handlers;
+using BotHATTwaffle2.Services.SRCDS;
 using Discord;
 using Discord.Addons.Interactive;
 using Discord.Commands;
@@ -13,14 +14,14 @@ namespace BotHATTwaffle2.Services.Playtesting
     {
         private readonly SocketCommandContext _context;
         private readonly InteractiveService _interactive;
-        private readonly DataService _dataService;
+        private readonly RconService _rconService;
         private readonly LogHandler _log;
 
-        public KickUserRcon(SocketCommandContext context, InteractiveService interactive, DataService data, LogHandler log)
+        public KickUserRcon(SocketCommandContext context, InteractiveService interactive, RconService rconService, LogHandler log)
         {
             _context = context;
             _interactive = interactive;
-            _dataService = data;
+            _rconService = rconService;
             _log = log;
         }
 
@@ -35,7 +36,7 @@ namespace BotHATTwaffle2.Services.Playtesting
             string description = null;
 
             //Get the raw status data
-            string input = await _dataService.RconCommand(serverAddress, "status");
+            string input = await _rconService.RconCommand(serverAddress, "status");
 
             //Format the raw data into an array and do some cleanup
             var players = input.Replace('\r', '\0').Split('\n').Where(x => x.StartsWith("#")).Select(y => y.Trim('#').Trim()).ToList();
@@ -65,7 +66,7 @@ namespace BotHATTwaffle2.Services.Playtesting
             var choice = await _interactive.NextMessageAsync(_context, timeout:TimeSpan.FromSeconds(20));
             if (choice != null && !choice.Content.Equals("0"))
             {
-                string kickMessage = await _dataService.RconCommand(serverAddress, $"kickid {choice.Content}");
+                string kickMessage = await _rconService.RconCommand(serverAddress, $"kickid {choice.Content}");
                 await choice.DeleteAsync();
 
                 embed.WithColor(new Color(55, 165, 55)).WithAuthor(kickMessage).WithDescription("");

--- a/BotHATTwaffle2/src/Services/SRCDS/LogReceiverService.cs
+++ b/BotHATTwaffle2/src/Services/SRCDS/LogReceiverService.cs
@@ -1,0 +1,154 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Reflection.Metadata.Ecma335;
+using System.Threading;
+using System.Threading.Tasks;
+using BotHATTwaffle2.Handlers;
+using BotHATTwaffle2.Models.LiteDB;
+using BotHATTwaffle2.Util;
+using CoreRCON;
+using CoreRCON.Parsers.Standard;
+namespace BotHATTwaffle2.Services.SRCDS
+{
+    public class LogReceiverService
+    {
+        private string _publicIpAddress = new WebClient().DownloadString("http://icanhazip.com/");
+        private readonly DataService _dataService;
+        private readonly RconService _rconService;
+        private readonly LogHandler _logHandler;
+        public bool enableLog = false;
+        public Server ActiveServer;
+        private string path;
+
+        public LogReceiverService(DataService dataService, RconService rconService, LogHandler logHandler)
+        {
+            _rconService = rconService;
+            _dataService = dataService;
+            _logHandler = logHandler;
+            SetFileName("feedback");
+        }
+
+        /// <summary>
+        /// Starts listening on a port for server messages. This will also add the location of the Bot to the server's log
+        /// address. The listening port needs to be forwarded on UDP
+        /// </summary>
+        /// <param name="serverString">Server to start listening on</param>
+        public async void StartLogReceiver(string serverString)
+        {
+            //Cannot start another sessions while one is active
+            if (enableLog)
+                return;
+
+            ActiveServer = DatabaseUtil.GetTestServer(serverString);
+
+            //Need a valid server
+            if (ActiveServer == null)
+                return;
+            
+            enableLog = true;
+            string externalip = new WebClient().DownloadString("http://icanhazip.com").Trim();
+            await _rconService.RconCommand(ActiveServer.ServerId, $"logaddress_add {externalip}:{_dataService.RSettings.ProgramSettings.ListenPort}");
+            
+
+
+            var ip = GeneralUtil.GetIPHost(ActiveServer.Address).AddressList.FirstOrDefault();
+            var log = new LogReceiver(_dataService.RSettings.ProgramSettings.ListenPort, new IPEndPoint(ip, 27015));
+
+            await _logHandler.LogMessage($"Starting LogReceiver for {ActiveServer.Address} using:\n" +
+                                         "logaddress_add " + externalip + ":" + _dataService.RSettings.ProgramSettings.ListenPort);
+
+            //Seed the feedback log with the current timestamp
+            await HandleInGameFeedback(ActiveServer, new FeedbackMessage
+            {
+                Message = $"Log Started at {DateTime.Now} CT",
+                Player = new Player
+                {
+                    Name = "Ido",
+                    Team = "Bot"
+                }
+
+            });
+
+            //Start the task and run it forever in a loop. The bool changes at a later time which breaks the loop
+            //and removes this client so we can make another one later on.
+            await Task.Run(async () =>
+            {
+                log.Listen<FeedbackMessage>(chat => { _ = HandleInGameFeedback(ActiveServer, chat); });
+
+                log.Listen<RconMessage>(rcon => { _ = InGameRcon(ActiveServer, rcon); });
+
+                while (enableLog)
+                {
+                    await Task.Delay(1000);
+                }
+
+            });
+            await _logHandler.LogMessage($"Disposing LogReceiver from `{ActiveServer.Address}` - `{ip}`");
+            log.Dispose();
+        }
+
+        //Stops listening for log messages and defaults a file for logging.
+        public void StopLogReceiver()
+        {
+            //Reset path to something default incase sessions is started outside of a test.
+            SetFileName("feedback");
+            enableLog = false;
+        }
+
+        /// <summary>
+        /// Checks if the user trying to use RCON is in the SteamID whitelist.
+        /// </summary>
+        /// <param name="server">Server to send RCON to</param>
+        /// <param name="rconMessage">Command to send</param>
+        /// <returns></returns>
+        private async Task InGameRcon(Server server, RconMessage rconMessage)
+        {
+            //Make sure the user has access
+            if (!_dataService.RSettings.Lists.SteamIDs.Any(x => x.Contains(rconMessage.Player.SteamId)))
+                return;
+
+            await _rconService.RconCommand(server.Address, rconMessage.Message);
+        }
+
+        /// <summary>
+        /// Adds ingame feedback to a text file which will be sent to the create at a later date.
+        /// </summary>
+        /// <param name="server">Server to send acks to</param>
+        /// <param name="message">Message to log</param>
+        /// <returns></returns>
+        private async Task HandleInGameFeedback(Server server, FeedbackMessage message)
+        {
+            Directory.CreateDirectory("Feedback");
+
+            if (!File.Exists(path))
+            {
+                // Create a file to write to.
+                using (StreamWriter sw = File.CreateText(path))
+                {
+                    sw.WriteLine($"{message.Player.Name} ({message.Player.Team}): {message.Message}");
+                }
+            }
+            else
+            // This text is always added, making the file longer over time
+            // if it is not deleted.
+            using (StreamWriter sw = File.AppendText(path))
+            {
+                sw.WriteLine($"{message.Player.Name} ({message.Player.Team}): {message.Message}");
+            }
+
+            await _rconService.RconCommand(server.ServerId, $"say Feedback from {message.Player.Name} captured!");
+        }
+
+        public void SetFileName(string fileName)
+        {
+            if (fileName.Contains(".txt"))
+                path = "Feedback/" + fileName;
+
+            path = "Feedback/" + fileName + ".txt";
+        }
+
+        public string GetFilePath() => path;
+    }
+}

--- a/BotHATTwaffle2/src/Services/SRCDS/RconService.cs
+++ b/BotHATTwaffle2/src/Services/SRCDS/RconService.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using BotHATTwaffle2.Handlers;
+using BotHATTwaffle2.Util;
+using CoreRCON;
+
+namespace BotHATTwaffle2.Services.SRCDS
+{
+    public class RconService
+    {
+        private readonly DataService _dataService;
+        private LogHandler _log;
+        private const ConsoleColor LOG_COLOR = ConsoleColor.Cyan;
+        private static Dictionary<string, RCON> _rconClients;
+
+        public RconService(DataService dataService, LogHandler log)
+        {
+            _dataService = dataService;
+            _log = log;
+
+            _rconClients = new Dictionary<string, RCON>();
+        }
+
+        private RCON GetOrCreateRconClient(string serverId)
+        {
+            if (!_rconClients.ContainsKey(serverId))
+            {
+                //Validate server before adding
+                var server = DatabaseUtil.GetTestServer(serverId);
+
+                //Server cannot be null.
+                if (server == null)
+                    throw new NullReferenceException(nameof(serverId));
+
+                var iPHostEntry = GeneralUtil.GetIPHost(server.Address);
+                
+                var rconClient = new RCON(iPHostEntry.AddressList.FirstOrDefault(),27015, server.RconPassword);
+                _rconClients.Add(serverId, rconClient);
+
+                rconClient.OnDisconnected += () =>
+                {
+                    _ = _log.LogMessage($"RCON client for `{serverId}` has been disposed.", channel:false, color:LOG_COLOR);
+                    _rconClients.Remove(serverId);
+                };
+
+                rconClient.OnLog += logMessage => {  _ = _log.LogMessage(logMessage, color:LOG_COLOR); };
+            }
+
+            return _rconClients[serverId];
+        }
+
+        public async Task<string> RconCommand(string serverId, string command)
+        {
+            string reply;
+            serverId = GeneralUtil.GetServerCode(serverId);
+            var client = GetOrCreateRconClient(serverId);
+            var commandResult =  client.SendCommandOrRetry(command);
+            if (commandResult == await Task.WhenAny(commandResult, Task.Delay(5000)))
+            {
+                reply = await commandResult;
+            }
+            else
+            {
+                //If we timed out, we can assume the server isn't going to reply on this session any more.
+                reply = "Timed out waiting for a reply, please try again";
+                client.Dispose();
+                _rconClients.Remove(serverId);
+            }
+
+            if (string.IsNullOrWhiteSpace(reply))
+                return $"{command} was sent, but provided no reply.";
+
+            reply = FormatRconServerReply(reply);
+
+            //Ignore logging status replies... This is a one off that just causes too much spam.
+            if(!command.Contains("status",StringComparison.OrdinalIgnoreCase))
+                await _log.LogMessage($"**Sending:** `{command}`\n**To:** `{serverId}`\n**Response Was:** `{reply}`", color: LOG_COLOR);
+
+            return reply;
+        }
+
+        /// <summary>
+        /// Gets status from server, then sets a parameter containing the player count of the server.
+        /// </summary>
+        /// <param name="serverId">SeverId to get status from</param>
+        /// <returns></returns>
+        public async Task GetPlayCountFromServer(string serverId)
+        {
+            var returned = await RconCommand(serverId, "status");
+            var replyArray = returned.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+            
+            //Only get the line with player count
+            var results = replyArray.Where(l => l.StartsWith("players"));
+            
+            //Remove extra information from string
+            var formatted = results.FirstOrDefault()?.Substring(10);
+            
+            _dataService.PlayerCount = formatted?.Substring(0, formatted.IndexOf(" ", StringComparison.Ordinal));
+            Console.WriteLine(_dataService.PlayerCount);
+        }
+
+        /// <summary>
+        /// Formats the reply for displaying to users. Removes log messages, and updates message if empty.
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        private string FormatRconServerReply(string input)
+        {
+            var replyArray = input.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+            return string.Join("\n", replyArray.Where(x => !x.Trim().StartsWith("L ")));
+        }
+    }
+}

--- a/BotHATTwaffle2/src/Util/GeneralUtil.cs
+++ b/BotHATTwaffle2/src/Util/GeneralUtil.cs
@@ -1,14 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Text.RegularExpressions;
 using BotHATTwaffle2.Handlers;
 using BotHATTwaffle2.Services;
 using Imgur.API.Authentication.Impl;
 using Imgur.API.Endpoints.Impl;
-using System.Drawing;
-using Discord.API;
-using RCONServerLib.Utils;
 using Color = Discord.Color;
 
 namespace BotHATTwaffle2.Util
@@ -154,6 +152,28 @@ namespace BotHATTwaffle2.Util
                 array[r] = array[i];
                 array[i] = t;
             }
+        }
+
+        /// <summary>
+        /// Gets a IPHostEntry from a FQDN or an IP address.
+        /// </summary>
+        /// <param name="address">FQDN or address</param>
+        /// <returns>Populated IPHostEntry object, null if not found</returns>
+        public static IPHostEntry GetIPHost(string address)
+        {
+            IPHostEntry iPHostEntry = null;
+            try
+            {
+                iPHostEntry = Dns.GetHostEntry(address);
+            }
+            catch (Exception e)
+            {
+                _ = _log.LogMessage($"Failed to get iPHostEntry for `{address}`", alert:true, color:LOG_COLOR);
+                Console.WriteLine(e);
+                throw;
+            }
+
+            return iPHostEntry;
         }
     }
 }

--- a/CoreRCON/Constants.cs
+++ b/CoreRCON/Constants.cs
@@ -1,0 +1,15 @@
+﻿namespace CoreRCON
+{
+	internal class Constants
+	{
+		/// <summary>
+		/// No-op command to send to the server.  Should be easily identifiable!
+		/// </summary>
+		internal const string CHECK_STR = "//OSW";
+
+		/// <summary>
+		/// The maximum size of an RCON packet.
+		/// </summary>
+		internal const int MAX_PACKET_SIZE = 4096;
+	}
+}

--- a/CoreRCON/CoreRCON.csproj
+++ b/CoreRCON/CoreRCON.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>A .NET Core implementation of the RCON spec.  Supports Source and Minecraft.</Description>
+    <AssemblyTitle>CoreRCON</AssemblyTitle>
+    <VersionPrefix>2.0.0</VersionPrefix>
+    <Authors>Scott Kaye</Authors>
+    <TargetFramework>netstandard1.6</TargetFramework>
+    <AssemblyName>CoreRCON</AssemblyName>
+    <OutputType>Library</OutputType>
+    <PackageId>CoreRCON</PackageId>
+    <PackageTags>valve;rcon;logaddress;srcds;minecraft</PackageTags>
+    <PackageIconUrl>https://cdn.rawgit.com/ScottKaye/CoreRCON/master/logo.png</PackageIconUrl>
+    <PackageProjectUrl>https://github.com/ScottKaye/CoreRCON</PackageProjectUrl>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/ScottKaye/CoreRCON</RepositoryUrl>
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <Version>3.0.0</Version>
+    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+  </PropertyGroup>
+
+  <Target Name="PostcompileScript" AfterTargets="Build" Condition=" '$(IsCrossTargetingBuild)' != 'true' ">
+    <Exec Command="dotnet pack --no-build --configuration $(Configuration)" />
+  </Target>
+
+</Project>

--- a/CoreRCON/Enums.cs
+++ b/CoreRCON/Enums.cs
@@ -1,0 +1,18 @@
+﻿namespace CoreRCON
+{
+	// SERVERDATA_AUTH_RESPONSE and SERVERDATA_EXECCOMMAND are both 2
+	public enum PacketType
+	{
+		// SERVERDATA_RESPONSE_VALUE
+		Response = 0,
+
+		// SERVERDATA_AUTH_RESPONSE
+		AuthResponse = 2,
+
+		// SERVERDATA_EXECCOMMAND
+		ExecCommand = 2,
+
+		// SERVERDATA_AUTH
+		Auth = 3
+	}
+}

--- a/CoreRCON/Exceptions.cs
+++ b/CoreRCON/Exceptions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace CoreRCON
+{
+	/// <summary>
+	/// Basically just another Exception.
+	/// </summary>
+	public class AuthenticationException : Exception
+	{
+		public AuthenticationException()
+		{
+		}
+
+		public AuthenticationException(string message) : base(message)
+		{
+		}
+
+		public AuthenticationException(string message, Exception innerException) : base(message, innerException)
+		{
+		}
+	}
+}

--- a/CoreRCON/Extensions.cs
+++ b/CoreRCON/Extensions.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CoreRCON
+{
+	internal static class Extensions
+	{
+		// Trick VS into thinking this is a resolved task
+		internal static void Forget(this Task task)
+		{
+		}
+
+		/// <summary>
+		/// Step through a byte array and read a null-terminated string.
+		/// </summary>
+		/// <param name="bytes">Byte array.</param>
+		/// <param name="start">Offset to start reading from.</param>
+		/// <param name="i">Offset variable to move to the end of the string.</param>
+		/// <returns>UTF-8 encoded string.</returns>
+		public static string ReadNullTerminatedString(this byte[] bytes, int start, ref int i)
+		{
+			int end = Array.IndexOf(bytes, (byte)0, start);
+			if (end < 0) throw new ArgumentOutOfRangeException("Byte array does not appear to contain a null byte to stop reading a string at.");
+			i = end + 1;
+			return Encoding.UTF8.GetString(bytes, start, end - start);
+		}
+
+        public static List<string> ReadNullTerminatedStringArray(this byte[] bytes, int start, ref int i)
+        {
+            var result = new List<string>();
+            var byteindex = start;
+            while (bytes[byteindex] != 0x00)
+            {
+                result.Add(ReadNullTerminatedString(bytes, byteindex, ref byteindex));
+            }
+            i = byteindex + 1;
+            return result;
+        }
+
+        public static Dictionary<string, string> ReadNullTerminatedStringDictionary(this byte[] bytes, int start, ref int i)
+        {
+            var result = new Dictionary<string, string>();
+            var byteindex = start;
+            while (bytes[byteindex] != 0x00)
+            {
+                result.Add(ReadNullTerminatedString(bytes, byteindex, ref byteindex), ReadNullTerminatedString(bytes, byteindex, ref byteindex));
+            }
+            i = byteindex + 1;
+            return result;
+        }
+
+		/// <summary>
+		/// Read a short from a byte array and update the offset.
+		/// </summary>
+		/// <param name="bytes">Byte array.</param>
+		/// <param name="start">Offset to start reading from.</param>
+		/// <param name="i">Offset variable to move to the end of the string.</param>
+		public static short ReadShort(this byte[] bytes, int start, ref int i)
+		{
+			i += 2;
+			return BitConverter.ToInt16(bytes, start);
+		}
+
+        /// <summary>
+        /// Read a float from a byte array and update the offset.
+        /// </summary>
+        /// <param name="bytes">Byte array.</param>
+        /// <param name="start">Offset to start reading from.</param>
+        /// <param name="i">Offset variable to move to the end of the string.</param>
+        public static float ReadFloat(this byte[] bytes, int start, ref int i)
+		{
+			i += 4;
+			return BitConverter.ToSingle(bytes, start);
+		}
+
+		/// <summary>
+		/// Truncate a string to a maximum length.
+		/// </summary>
+		/// <param name="str">String to truncate.</param>
+		/// <param name="maxLength">Maximum length of the string.</param>
+		/// <returns>Truncated string with ellipses, or the original string.</returns>
+		internal static string Truncate(this string str, int maxLength)
+		{
+			return str?.Length <= maxLength
+				? str
+				: str.Substring(0, maxLength - 3) + "...";
+		}
+	}
+}

--- a/CoreRCON/LogReceiver.cs
+++ b/CoreRCON/LogReceiver.cs
@@ -1,0 +1,115 @@
+﻿using CoreRCON.PacketFormats;
+using CoreRCON.Parsers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+
+namespace CoreRCON
+{
+	public class LogReceiver : IDisposable
+	{
+		public int ResolvedPort
+		{
+			get
+			{
+				if (_udp == null) return 0;
+				return ((IPEndPoint)(_udp.Client.LocalEndPoint)).Port;
+			}
+		}
+
+		private List<Action<LogAddressPacket>> _logListeners { get; } = new List<Action<LogAddressPacket>>();
+		private List<ParserContainer> _parseListeners { get; } = new List<ParserContainer>();
+		private List<Action<string>> _rawListeners { get; } = new List<Action<string>>();
+		private UdpClient _udp { get; set; }
+		private IPEndPoint[] _sources { get; set; }
+
+		/// <summary>
+		/// Opens a socket to receive LogAddress logs, and registers it with the server.  The IP can also be a local IP if the server is on the same network.
+		/// </summary>
+		/// <param name="port">Local port to bind to.</param>
+		/// <param name="sources">Array of endpoints to accept logaddress packets from.  The server you plan on receiving packets from must be in this list.</param>
+		public LogReceiver(ushort port, params IPEndPoint[] sources)
+		{
+			_sources = sources;
+			_udp = new UdpClient(port);
+			Task.Run(() => StartListener());
+		}
+
+		public void Dispose()
+		{
+			_udp.Dispose();
+		}
+
+		/// <summary>
+		/// Listens on the socket for a parseable class to read.
+		/// </summary>
+		/// <typeparam name="T">Class to be parsed; must have a ParserAttribute.</typeparam>
+		/// <param name="result">Parsed class.</param>
+		public void Listen<T>(Action<T> result)
+			where T : class, IParseable, new()
+		{
+			// Instantiate the parser associated with the type parameter
+			var instance = ParserHelpers.CreateParser<T>();
+
+			// Create the parser container
+			_parseListeners.Add(new ParserContainer
+			{
+				IsMatch = line => instance.IsMatch(line),
+				Parse = line => instance.Parse(line),
+				Callback = parsed => result((T)parsed)
+			});
+		}
+
+		/// <summary>
+		/// Listens on the socket for anything from LogAddress, returning the full packet.
+		/// </summary>
+		/// <param name="result">Parsed LogAddress packet.</param>
+		public void ListenPacket(Action<LogAddressPacket> result) => _logListeners.Add(result);
+
+		/// <summary>
+		/// Listens on the socket for anything, returning just the body of the packet.
+		/// </summary>
+		/// <param name="result">Raw string returned by the server.</param>
+		public void ListenRaw(Action<string> result) => _rawListeners.Add(result);
+
+		private void LogAddressPacketReceived(LogAddressPacket packet)
+		{
+			// Filter out checks (if there is one)
+			if (RCON.Identifier.Length > 0 && packet.Body.Contains(Constants.CHECK_STR + RCON.Identifier))
+				return;
+
+			// Call LogAddress listeners
+			foreach (var listener in _logListeners)
+				listener?.Invoke(packet);
+
+			string body = packet.Body;
+			if (body.Length == 0) return;
+
+			// Call parsers
+			foreach (var parser in _parseListeners)
+				parser.TryCallback(body);
+
+			// Call raw listeners
+			foreach (var listener in _rawListeners)
+				listener?.Invoke(body);
+		}
+
+		private async Task StartListener()
+		{
+			while (true)
+			{
+				var result = await _udp.ReceiveAsync();
+
+				// If the packet did not come from an accepted source, throw it out
+				if (!_sources.Contains(result.RemoteEndPoint)) return;
+
+				// Parse out the LogAddress packet
+				LogAddressPacket packet = LogAddressPacket.FromBytes(result.Buffer);
+				LogAddressPacketReceived(packet);
+			}
+		}
+	}
+}

--- a/CoreRCON/PacketFormats/IQueryInfo.cs
+++ b/CoreRCON/PacketFormats/IQueryInfo.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CoreRCON.PacketFormats
+{
+    public interface IQueryInfo
+    {
+    }
+}

--- a/CoreRCON/PacketFormats/LogAddressPacket.cs
+++ b/CoreRCON/PacketFormats/LogAddressPacket.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace CoreRCON.PacketFormats
+{
+	// Structure of a LogAddress packet from SRCDS:
+	// 255 255 255 255
+	// 82 or 83 (82 = no password, 83 = password)
+	// if 82, the rest of the packet is the body.
+	// Not sure what happens if it's 83, since I can't get my test server to return one even with sv_logsecret set.
+
+	public struct LogAddressPacket
+	{
+		/// <summary>
+		/// The body of the packet with the timestamp removed.
+		/// </summary>
+		public readonly string Body;
+
+		/// <summary>
+		/// [UNSUPPORTED] If the packet was sent with sv_logsecret set.
+		/// </summary>
+		public readonly bool HasPassword;
+
+		/// <summary>
+		/// The raw body of the packet.
+		/// </summary>
+		public readonly string RawBody;
+
+		/// <summary>
+		/// The timestamp at which the packet was sent (not received).
+		/// </summary>
+		public readonly DateTime Timestamp;
+
+		/// <summary>
+		/// Create a new packet.
+		/// </summary>
+		/// <param name="hasPassword">[UNSUPPORTED] If the server returned this packet with sv_logsecret set.</param>
+		/// <param name="rawBody">The raw body from the packet.</param>
+		public LogAddressPacket(bool hasPassword, string rawBody)
+		{
+			HasPassword = hasPassword;
+			RawBody = rawBody;
+
+			// Get timestamp
+			// https://developer.valvesoftware.com/wiki/HL_Log_Standard
+			var match = new Regex(@"L (\d{2}/\d{2}/\d{4} - \d{2}:\d{2}:\d{2}):").Match(rawBody);
+			if (match.Success)
+			{
+				var value = match.Groups[1].Value;
+				Timestamp = DateTime.ParseExact(value, "MM/dd/yyyy - HH:mm:ss", CultureInfo.InvariantCulture);
+			}
+			else
+			{
+				Timestamp = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+			}
+
+			// Get body without the date/time
+			Body = rawBody.Substring(25);
+		}
+
+		public override string ToString() => RawBody;
+
+		/// <summary>
+		/// Converts a buffer to a packet.
+		/// </summary>
+		/// <param name="buffer">Buffer to read.</param>
+		/// <returns>Created packet.</returns>
+		internal static LogAddressPacket FromBytes(byte[] buffer)
+		{
+			if (buffer.Length < 7) throw new InvalidDataException("LogAddress packet is of an invalid length.");
+			if (!buffer.Take(4).SequenceEqual(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF })) throw new InvalidDataException("LogAddress packet does not contain a valid header.");
+
+			// 83 = magic byte
+			bool hasPassword = buffer[5] == 83;
+
+			try
+			{
+				// Force string to \r\n line endings
+				string body = new string(Encoding.UTF8.GetChars(buffer, 5, buffer.Length - 7));
+				body = Regex.Replace(body, @"\r\n|\n\r|\n|\r", "\r\n");
+				return new LogAddressPacket(hasPassword, body);
+			}
+			catch (Exception ex)
+			{
+				Console.Error.WriteLine($"{DateTime.Now} - Error reading logaddress packet from server: " + ex.Message);
+				return new LogAddressPacket(hasPassword, "");
+			}
+		}
+	}
+}

--- a/CoreRCON/PacketFormats/MinecraftQueryPackets.cs
+++ b/CoreRCON/PacketFormats/MinecraftQueryPackets.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+
+namespace CoreRCON.PacketFormats
+{
+    public class MinecraftQueryInfo : IQueryInfo
+    {
+        public string MessageOfTheDay { get; private set; }
+        public string Gametype { get; private set; }
+        public string GameId { get; private set; }
+        public string Version { get; private set; }
+        public string Plugins { get; private set; }
+        public string Map { get; private set; }
+        public string NumPlayers { get; private set; }
+        public string MaxPlayers { get; private set; }
+        public string HostPort { get; private set; }
+        public string HostIp { get; private set; }
+
+        public IEnumerable<string> Players { get; private set; }
+
+        public static MinecraftQueryInfo FromBytes(byte[] buffer)
+        {
+            int i = 16; // 1x type, 4x session, 11x padding
+            var serverinfo = buffer.ReadNullTerminatedStringDictionary(i, ref i);
+            i += 10;
+            var players = buffer.ReadNullTerminatedStringArray(i, ref i);
+
+            return new MinecraftQueryInfo
+            {
+                MessageOfTheDay = serverinfo["hostname"],
+                Gametype = serverinfo["gametype"],
+                GameId = serverinfo["game_id"],
+                Version = serverinfo["version"],
+                Plugins = serverinfo["plugins"],
+                Map = serverinfo["map"],
+                NumPlayers = serverinfo["numplayers"],
+                MaxPlayers = serverinfo["maxplayers"],
+                HostPort = serverinfo["hostport"],
+                HostIp = serverinfo["hostip"],
+                Players = players
+            };
+        }
+    }
+}

--- a/CoreRCON/PacketFormats/RCONPacket.cs
+++ b/CoreRCON/PacketFormats/RCONPacket.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace CoreRCON.PacketFormats
+{
+	public class RCONPacket
+	{
+		public string Body { get; private set; }
+		public int Id { get; private set; }
+		public PacketType Type { get; private set; }
+
+		/// <summary>
+		/// Create a new packet.
+		/// </summary>
+		/// <param name="id">Some kind of identifier to keep track of responses from the server.</param>
+		/// <param name="type">What the server is supposed to do with the body of this packet.</param>
+		/// <param name="body">The actual information held within.</param>
+		public RCONPacket(int id, PacketType type, string body)
+		{
+			Id = id;
+			Type = type;
+			Body = body;
+		}
+
+		public override string ToString() => Body;
+
+		/// <summary>
+		/// Converts a buffer to a packet.
+		/// </summary>
+		/// <param name="buffer">Buffer to read.</param>
+		/// <returns>Created packet.</returns>
+		internal static RCONPacket FromBytes(byte[] buffer)
+		{
+			if (buffer == null) throw new NullReferenceException("Byte buffer cannot be null.");
+			if (buffer.Length < 4) throw new InvalidDataException("Buffer does not contain a size field.");
+			if (buffer.Length > Constants.MAX_PACKET_SIZE) throw new InvalidDataException("Buffer is too large for an RCON packet.");
+
+			int size = BitConverter.ToInt32(buffer, 0);
+
+			if (size < 10) throw new InvalidDataException("Packet received was invalid.");
+
+			int id = BitConverter.ToInt32(buffer, 4);
+			PacketType type = (PacketType)BitConverter.ToInt32(buffer, 8);
+
+			try
+			{
+				// Force string to \r\n line endings
+				char[] rawBody = Encoding.UTF8.GetChars(buffer, 12, size - 10);
+				string body = new string(rawBody, 0, size - 10).TrimEnd();
+				body = Regex.Replace(body, @"\r\n|\n\r|\n|\r", "\r\n");
+				return new RCONPacket(id, type, body);
+			}
+			catch (Exception ex)
+			{
+				Console.Error.WriteLine($"{DateTime.Now} - Error reading RCON packet from server: " + ex.Message);
+				return new RCONPacket(id, type, "");
+			}
+		}
+
+		/// <summary>
+		/// Serializes a packet to a byte array for transporting over a network.  Body is serialized as UTF8.
+		/// </summary>
+		/// <returns>Byte array with each field.</returns>
+		internal byte[] ToBytes()
+		{
+			byte[] body = Encoding.UTF8.GetBytes(Body + "\0");
+			int bl = body.Length;
+
+			using (var packet = new MemoryStream(12 + bl))
+			{
+				packet.Write(BitConverter.GetBytes(9 + bl), 0, 4);
+				packet.Write(BitConverter.GetBytes(Id), 0, 4);
+				packet.Write(BitConverter.GetBytes((int)Type), 0, 4);
+				packet.Write(body, 0, bl);
+				packet.Write(new byte[] { 0 }, 0, 1);
+
+				return packet.ToArray();
+			}
+		}
+	}
+}

--- a/CoreRCON/PacketFormats/SourceQueryPackets.cs
+++ b/CoreRCON/PacketFormats/SourceQueryPackets.cs
@@ -1,0 +1,94 @@
+﻿namespace CoreRCON.PacketFormats
+{
+	public enum ServerEnvironment
+	{
+		Linux = 0x6C,
+		Windows = 0x77,
+		Mac = 0x6F
+	}
+
+	public enum ServerType
+	{
+		Dedicated = 0x64,
+		NonDedicated = 0x6C,
+		SourceTV = 0x70
+	}
+
+	public enum ServerVAC
+	{
+		Unsecured = 0x0,
+		Secured = 0x1
+	}
+
+	public enum ServerVisibility
+	{
+		Public = 0x0,
+		Private = 0x1
+	}
+
+	public class SourceQueryInfo : IQueryInfo
+    {
+		public byte Bots { get; private set; }
+		public ServerEnvironment Environment { get; private set; }
+		public string Folder { get; private set; }
+		public string Game { get; private set; }
+		public short GameId { get; private set; }
+		public string Map { get; private set; }
+		public byte MaxPlayers { get; private set; }
+		public string Name { get; private set; }
+		public byte Players { get; private set; }
+		public byte ProtocolVersion { get; private set; }
+		public ServerType Type { get; private set; }
+		public ServerVAC VAC { get; private set; }
+		public ServerVisibility Visibility { get; private set; }
+
+		public static SourceQueryInfo FromBytes(byte[] buffer)
+		{
+			int i = 6;
+			return new SourceQueryInfo
+			{
+				ProtocolVersion = buffer[4],
+				Name = buffer.ReadNullTerminatedString(i, ref i),
+				Map = buffer.ReadNullTerminatedString(i, ref i),
+				Folder = buffer.ReadNullTerminatedString(i, ref i),
+				Game = buffer.ReadNullTerminatedString(i, ref i),
+				GameId = buffer.ReadShort(i, ref i),
+				Players = buffer[i++],
+				MaxPlayers = buffer[i++],
+				Bots = buffer[i++],
+				Type = (ServerType)buffer[i++],
+				Environment = (ServerEnvironment)buffer[i++],
+				Visibility = (ServerVisibility)buffer[i++],
+				VAC = (ServerVAC)buffer[i++]
+			};
+		}
+	}
+
+	public class ServerQueryPlayer
+	{
+		public float Duration { get; private set; }
+		public string Name { get; private set; }
+		public short Score { get; private set; }
+
+		public static ServerQueryPlayer[] FromBytes(byte[] buffer)
+		{
+			int i = 7;
+
+			ServerQueryPlayer[] players = new ServerQueryPlayer[buffer[5]];
+
+			for (int p = 0; p < players.Length; ++p)
+			{
+				players[p] = new ServerQueryPlayer
+				{
+					Name = buffer.ReadNullTerminatedString(i, ref i),
+					Score = buffer.ReadShort(i, ref i),
+					Duration = buffer.ReadFloat(i + 2, ref i)
+				};
+
+				i += 3;
+			}
+
+			return players;
+		}
+	}
+}

--- a/CoreRCON/Parsers/DefaultParser.cs
+++ b/CoreRCON/Parsers/DefaultParser.cs
@@ -1,0 +1,26 @@
+﻿using System.Text.RegularExpressions;
+
+namespace CoreRCON.Parsers
+{
+	/// <summary>
+	/// Default implementation of IParser(T)
+	/// </summary>
+	/// <typeparam name="T">Type of object the parser returns.</typeparam>
+	public abstract class DefaultParser<T> : IParser<T>
+		where T : class, IParseable
+	{
+		public abstract string Pattern { get; }
+
+		public virtual bool IsMatch(string input) => new Regex(Pattern, RegexOptions.Singleline).IsMatch(input);
+
+		public abstract T Load(GroupCollection groups);
+
+		public virtual T Parse(Group group) => Parse(group.Value);
+
+		public T Parse(string input)
+		{
+			var groups = new Regex(Pattern, RegexOptions.Singleline).Match(input).Groups;
+			return Load(groups);
+		}
+	}
+}

--- a/CoreRCON/Parsers/IParser.cs
+++ b/CoreRCON/Parsers/IParser.cs
@@ -1,0 +1,42 @@
+﻿using System.Text.RegularExpressions;
+
+namespace CoreRCON.Parsers
+{
+	// Purely for type constraints
+	public interface IParseable { }
+
+	public interface IParser { }
+
+	public interface IParser<T> : IParser
+		where T : class
+	{
+		/// <summary>
+		/// Regex pattern used to match this item.
+		/// </summary>
+		string Pattern { get; }
+
+		/// <summary>
+		/// Returns if the line received from the server can be parsed into the desired type.
+		/// </summary>
+		/// <param name="input">Single line from the server.</param>
+		bool IsMatch(string input);
+
+		/// <summary>
+		/// Allows the parser to be called from another parser that included this parser's pattern.
+		/// </summary>
+		/// <param name="groups">GroupCollection returned by the other parser.</param>
+		T Load(GroupCollection groups);
+
+		/// <summary>
+		/// Parses the line from the server into the desired type.
+		/// </summary>
+		/// <param name="input">Single line from the server.</param>
+		T Parse(string input);
+
+		/// <summary>
+		/// Convenience method for nested capture groups.
+		/// </summary>
+		/// <param name="group">Group with .Value property to read.</param>
+		T Parse(Group group);
+	}
+}

--- a/CoreRCON/Parsers/ParserContainer.cs
+++ b/CoreRCON/Parsers/ParserContainer.cs
@@ -1,0 +1,45 @@
+﻿using System;
+
+namespace CoreRCON.Parsers
+{
+	/// <summary>
+	/// Holds callbacks non-generically.
+	/// </summary>
+	internal class ParserContainer
+	{
+		internal Action<object> Callback { get; set; }
+		internal Func<string, bool> IsMatch { get; set; }
+		internal Func<string, object> Parse { get; set; }
+
+		/// <summary>
+		/// Attempt to parse the line, and call the callback if it succeeded.
+		/// </summary>
+		/// <param name="line">Single line from the server.</param>
+		internal void TryCallback(string line)
+		{
+			object result;
+			if (TryParse(line, out result))
+			{
+				Callback(result);
+			}
+		}
+
+		/// <summary>
+		/// Attempt to parse the line into an object.
+		/// </summary>
+		/// <param name="line">Single line from the server.</param>
+		/// <param name="result">Object to parse into.</param>
+		/// <returns>False if the match failed or parsing was unsuccessful.</returns>
+		private bool TryParse(string line, out object result)
+		{
+			if (!IsMatch(line))
+			{
+				result = null;
+				return false;
+			}
+
+			result = Parse(line);
+			return result != null;
+		}
+	}
+}

--- a/CoreRCON/Parsers/ParserHelpers.cs
+++ b/CoreRCON/Parsers/ParserHelpers.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+
+namespace CoreRCON.Parsers
+{
+	internal static class ParserHelpers
+	{
+		internal static IParser<T> CreateParser<T>()
+			where T : class, IParseable, new()
+		{
+			var implementor = new T().GetType().GetTypeInfo().Assembly.GetTypes().FirstOrDefault(t => t.GetTypeInfo().GetInterfaces().Contains(typeof(IParser<T>)));
+			if (implementor == null) throw new ArgumentException($"A class implementing {nameof(IParser)}<{typeof(T).FullName}> was not found in the assembly.");
+			return (IParser<T>)Activator.CreateInstance(implementor);
+		}
+	}
+}

--- a/CoreRCON/Parsers/Standard/ChatMessage.cs
+++ b/CoreRCON/Parsers/Standard/ChatMessage.cs
@@ -1,0 +1,33 @@
+﻿using System.Text.RegularExpressions;
+
+namespace CoreRCON.Parsers.Standard
+{
+	public enum MessageChannel
+	{
+		Team,
+		All
+	}
+
+	public class ChatMessage : IParseable
+	{
+		public MessageChannel Channel { get; set; }
+		public string Message { get; set; }
+		public Player Player { get; set; }
+	}
+
+	public class ChatMessageParser : DefaultParser<ChatMessage>
+	{
+        public override string Pattern { get; } = $"(?<Sender>{playerParser.Pattern}) (?<Channel>say_team|say) \"(?<Message>.+?)\"";
+        private static PlayerParser playerParser { get; } = new PlayerParser();
+
+		public override ChatMessage Load(GroupCollection groups)
+		{
+			return new ChatMessage
+			{
+				Player = playerParser.Parse(groups["Sender"]),
+				Message = groups["Message"].Value,
+				Channel = groups["Channel"].Value == "say" ? MessageChannel.All : MessageChannel.Team
+			};
+		}
+	}
+}

--- a/CoreRCON/Parsers/Standard/FeedbackMessage.cs
+++ b/CoreRCON/Parsers/Standard/FeedbackMessage.cs
@@ -1,0 +1,27 @@
+﻿using System.Text.RegularExpressions;
+
+namespace CoreRCON.Parsers.Standard
+{
+    public class FeedbackMessage : IParseable
+    {
+        public MessageChannel Channel { get; set; }
+        public string Message { get; set; }
+        public Player Player { get; set; }
+    }
+
+    public class FeedbackMessageParser : DefaultParser<FeedbackMessage>
+    {
+        public override string Pattern { get; } = $"(?<Sender>{playerParser.Pattern}) (?<Channel>say_team|say) \">(fb|feedback)\\s?(?<Message>.+?)\"";
+        private static PlayerParser playerParser { get; } = new PlayerParser();
+
+        public override FeedbackMessage Load(GroupCollection groups)
+        {
+            return new FeedbackMessage
+            {
+                Player = playerParser.Parse(groups["Sender"]),
+                Message = groups["Message"].Value,
+                Channel = groups["Channel"].Value == "say" ? MessageChannel.All : MessageChannel.Team
+            };
+        }
+    }
+}

--- a/CoreRCON/Parsers/Standard/KillFeed.cs
+++ b/CoreRCON/Parsers/Standard/KillFeed.cs
@@ -1,0 +1,27 @@
+﻿using System.Text.RegularExpressions;
+
+namespace CoreRCON.Parsers.Standard
+{
+	public class KillFeed : IParseable
+	{
+		public Player Killed { get; set; }
+		public Player Killer { get; set; }
+		public string Weapon { get; set; }
+	}
+
+	public class KillFeedParser : DefaultParser<KillFeed>
+	{
+		public override string Pattern { get; } = $"(?<Killer>{playerParser.Pattern}) killed (?<Killed>{playerParser.Pattern}) with \"(?<Weapon>.+?)\"";
+		private static PlayerParser playerParser { get; } = new PlayerParser();
+
+		public override KillFeed Load(GroupCollection groups)
+		{
+			return new KillFeed
+			{
+				Killer = playerParser.Parse(groups["Killer"]),
+				Killed = playerParser.Parse(groups["Killed"]),
+				Weapon = groups["Weapon"].Value
+			};
+		}
+	}
+}

--- a/CoreRCON/Parsers/Standard/NameChange.cs
+++ b/CoreRCON/Parsers/Standard/NameChange.cs
@@ -1,0 +1,25 @@
+﻿using System.Text.RegularExpressions;
+
+namespace CoreRCON.Parsers.Standard
+{
+	public class NameChange : IParseable
+	{
+		public string NewName { get; set; }
+		public Player Player { get; set; }
+	}
+
+	public class NameChangeParser : DefaultParser<NameChange>
+	{
+		public override string Pattern { get; } = $"(?<Player>{playerParser.Pattern}) changed name to \"(?<Name>.+?)\"$";
+		private static PlayerParser playerParser { get; } = new PlayerParser();
+
+		public override NameChange Load(GroupCollection groups)
+		{
+			return new NameChange
+			{
+				Player = playerParser.Parse(groups["Player"]),
+				NewName = groups["Name"].Value
+			};
+		}
+	}
+}

--- a/CoreRCON/Parsers/Standard/Player.cs
+++ b/CoreRCON/Parsers/Standard/Player.cs
@@ -1,0 +1,28 @@
+﻿using System.Text.RegularExpressions;
+
+namespace CoreRCON.Parsers.Standard
+{
+	public class Player : IParseable
+	{
+		public int ClientId { get; set; }
+		public string Name { get; set; }
+		public string SteamId { get; set; }
+		public string Team { get; set; }
+	}
+
+	public class PlayerParser : DefaultParser<Player>
+	{
+		public override string Pattern { get; } = "\"(?<Name>.+?(?:<.*>)*)<(?<ClientID>\\d+?)><(?<SteamID>.+?)><(?<Team>.+?)?>\"";
+
+		public override Player Load(GroupCollection groups)
+		{
+			return new Player
+			{
+				Name = groups["Name"].Value,
+				SteamId = groups["SteamID"].Value,
+				ClientId = int.Parse(groups["ClientID"].Value),
+				Team = groups["Team"].Value
+			};
+		}
+	}
+}

--- a/CoreRCON/Parsers/Standard/PlayerConnected.cs
+++ b/CoreRCON/Parsers/Standard/PlayerConnected.cs
@@ -1,0 +1,25 @@
+﻿using System.Text.RegularExpressions;
+
+namespace CoreRCON.Parsers.Standard
+{
+	public class PlayerConnected : IParseable
+	{
+		public string Host { get; set; }
+		public Player Player { get; set; }
+	}
+
+	public class PlayerConnectedParser : DefaultParser<PlayerConnected>
+	{
+		public override string Pattern { get; } = $"(?<Player>{playerParser.Pattern}) connected, address \"(?<Host>.+?)\"";
+		private static PlayerParser playerParser { get; } = new PlayerParser();
+
+		public override PlayerConnected Load(GroupCollection groups)
+		{
+			return new PlayerConnected
+			{
+				Player = playerParser.Parse(groups["Player"]),
+				Host = groups["Host"].Value
+			};
+		}
+	}
+}

--- a/CoreRCON/Parsers/Standard/PlayerDisconnected.cs
+++ b/CoreRCON/Parsers/Standard/PlayerDisconnected.cs
@@ -1,0 +1,23 @@
+﻿using System.Text.RegularExpressions;
+
+namespace CoreRCON.Parsers.Standard
+{
+	public class PlayerDisconnected : IParseable
+	{
+		public Player Player { get; set; }
+	}
+
+	public class PlayerDisconnectedParser : DefaultParser<PlayerDisconnected>
+	{
+		public override string Pattern { get; } = $"(?<Player>{playerParser.Pattern}) disconnected";
+		private static PlayerParser playerParser { get; } = new PlayerParser();
+
+		public override PlayerDisconnected Load(GroupCollection groups)
+		{
+			return new PlayerDisconnected
+			{
+				Player = playerParser.Parse(groups["Player"])
+			};
+		}
+	}
+}

--- a/CoreRCON/Parsers/Standard/README.md
+++ b/CoreRCON/Parsers/Standard/README.md
@@ -1,0 +1,3 @@
+﻿# Standard Parsers
+
+Most of these are following [Valve's HL Log Standard](https://developer.valvesoftware.com/wiki/HL_Log_Standard) document.

--- a/CoreRCON/Parsers/Standard/RconMessage.cs
+++ b/CoreRCON/Parsers/Standard/RconMessage.cs
@@ -1,0 +1,27 @@
+﻿using System.Text.RegularExpressions;
+
+namespace CoreRCON.Parsers.Standard
+{
+    public class RconMessage : IParseable
+    {
+        public MessageChannel Channel { get; set; }
+        public string Message { get; set; }
+        public Player Player { get; set; }
+    }
+
+    public class RconMessageParser : DefaultParser<RconMessage>
+    {
+        public override string Pattern { get; } = $"(?<Sender>{playerParser.Pattern}) (?<Channel>say_team|say) \">(r|rcon)\\s(?<Message>.+?)\"";
+        private static PlayerParser playerParser { get; } = new PlayerParser();
+
+        public override RconMessage Load(GroupCollection groups)
+        {
+            return new RconMessage
+            {
+                Player = playerParser.Parse(groups["Sender"]),
+                Message = groups["Message"].Value,
+                Channel = groups["Channel"].Value == "say" ? MessageChannel.All : MessageChannel.Team
+            };
+        }
+    }
+}

--- a/CoreRCON/Parsers/Standard/Status.cs
+++ b/CoreRCON/Parsers/Standard/Status.cs
@@ -1,0 +1,51 @@
+﻿using System.Text.RegularExpressions;
+
+namespace CoreRCON.Parsers.Standard
+{
+	public class Status : IParseable
+	{
+		public string Account { get; set; }
+		public byte Bots { get; set; }
+		public ulong CommunityID { get; set; }
+		public string Hostname { get; set; }
+		public byte Humans { get; set; }
+		public string LocalHost { get; set; }
+		public string Map { get; set; }
+		public byte MaxPlayers { get; set; }
+		public string PublicHost { get; set; }
+		public string SteamID { get; set; }
+		public string[] Tags { get; set; }
+		public string Version { get; set; }
+	}
+
+	internal class StatusParser : DefaultParser<Status>
+	{
+		public override string Pattern { get; } = @"hostname\s*: (?<Hostname>.+?)
+version\s*: (?<Version>.+?)
+udp\/ip\s*: (?<LocalHost>.+?)  \(public ip: (?<PublicHost>.+?)\)
+steamid\s*: \[(?<SteamID>.+?)\] \((?<CommunityID>\d+)\)
+account\s*: (?<Account>.+?)
+map\s*: (?<Map>.+?) at: .*
+tags\s*: (?<Tags>.+?)
+players\s*: (?<Humans>\d+) humans, (?<Bots>\d+) bots \((?<MaxPlayers>\d+) max\)";
+
+		public override Status Load(GroupCollection groups)
+		{
+			return new Status
+			{
+				Hostname = groups["Hostname"].Value,
+				Version = groups["Version"].Value,
+				LocalHost = groups["LocalHost"].Value,
+				PublicHost = groups["PublicHost"].Value,
+				SteamID = groups["SteamID"].Value,
+				CommunityID = ulong.Parse(groups["CommunityID"].Value),
+				Account = groups["Account"].Value,
+				Map = groups["Map"].Value,
+				Tags = groups["Tags"].Value.Split(','),
+				Humans = byte.Parse(groups["Humans"].Value),
+				Bots = byte.Parse(groups["Bots"].Value),
+				MaxPlayers = byte.Parse(groups["MaxPlayers"].Value)
+			};
+		}
+	}
+}

--- a/CoreRCON/Parsers/Standard/TeamChange.cs
+++ b/CoreRCON/Parsers/Standard/TeamChange.cs
@@ -1,0 +1,25 @@
+﻿using System.Text.RegularExpressions;
+
+namespace CoreRCON.Parsers.Standard
+{
+	public class TeamChange : IParseable
+	{
+		public Player Player { get; set; }
+		public string Team { get; set; }
+	}
+
+	public class TeamChangeParser : DefaultParser<TeamChange>
+	{
+		public override string Pattern { get; } = $"(?<Player>{playerParser.Pattern}) joined team \"(?<Team>.+?)\"";
+		private static PlayerParser playerParser { get; } = new PlayerParser();
+
+		public override TeamChange Load(GroupCollection groups)
+		{
+			return new TeamChange
+			{
+				Player = playerParser.Parse(groups["Player"]),
+				Team = groups["Team"].Value
+			};
+		}
+	}
+}

--- a/CoreRCON/Properties/AssemblyInfo.cs
+++ b/CoreRCON/Properties/AssemblyInfo.cs
@@ -1,0 +1,18 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("CoreRCON")]
+[assembly: AssemblyTrademark("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("a7bb2752-96c9-40e6-b3ba-26cd42cdb8f1")]

--- a/CoreRCON/RCON.cs
+++ b/CoreRCON/RCON.cs
@@ -1,0 +1,278 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using CoreRCON.PacketFormats;
+using CoreRCON.Parsers;
+
+namespace CoreRCON
+{
+    public class RCON : IDisposable
+    {
+        internal static string Identifier = "";
+        private readonly object _lock = new object();
+
+        // Allows us to keep track of when authentication succeeds, so we can block Connect from returning until it does.
+        private TaskCompletionSource<bool> _authenticationTask;
+
+        private bool _connected;
+        
+        private readonly IPEndPoint _endpoint;
+
+        // When generating the packet ID, use a never-been-used (for automatic packets) ID.
+        private int _packetId = 1;
+
+        private readonly string _password;
+        private uint _reconnectDelay;
+
+        /// <summary>
+        ///     Initialize an RCON connection and automatically call ConnectAsync().
+        /// </summary>
+        public RCON(IPAddress host, ushort port, string password, uint reconnectDelay = 30000)
+            : this(new IPEndPoint(host, port), password, reconnectDelay)
+        {
+        }
+
+        /// <summary>
+        ///     Initialize an RCON connection and automatically call ConnectAsync().
+        /// </summary>
+        public RCON(IPEndPoint endpoint, string password, uint reconnectDelay = 30000)
+        {
+            _endpoint = endpoint;
+            _password = password;
+            _reconnectDelay = reconnectDelay;
+            
+            try
+            {
+                ConnectAsync().Wait();
+            }
+            catch
+            {
+                Log($"RCON failed to connect to {_endpoint}");
+            }
+        }
+
+        // Map of pending command references.  These are called when a command with the matching Id (key) is received.  Commands are called only once.
+        private Dictionary<int, Action<string>> _pendingCommands { get; } = new Dictionary<int, Action<string>>();
+
+        private Socket _tcp { get; set; }
+
+        public void Dispose()
+        {
+            OnDisconnected();
+            _connected = false;
+            try
+            {
+                _tcp.Shutdown(SocketShutdown.Both);
+            }
+            catch
+            {
+                Console.WriteLine("Unable to properly shutdown TCP Socket. This is likely because of a network issue.");
+            }
+
+            try
+            {
+                _tcp.Dispose();
+            }
+            catch
+            {
+                Console.WriteLine("Unable to properly dispose TCP Socket. This is likely because of a network issue.");
+            }
+        }
+
+        public event Action OnDisconnected;
+
+        public event LogEventHandler OnLog;
+
+        public delegate void LogEventHandler(string message);
+
+        private void Log(string message)
+        {
+            if (OnLog != null)
+                OnLog(message);
+        }
+
+        /// <summary>
+        ///     Connect to a server through RCON.  Automatically sends the authentication packet.
+        /// </summary>
+        /// <returns>Awaitable which will complete when a successful connection is made and authentication is successful.</returns>
+        public async Task ConnectAsync()
+        {
+            _tcp = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            await _tcp.ConnectAsync(_endpoint);
+            _connected = true;
+
+            // Set up TCP listener
+            var e = new SocketAsyncEventArgs();
+            e.Completed += TCPPacketReceived;
+            e.SetBuffer(new byte[Constants.MAX_PACKET_SIZE], 0, Constants.MAX_PACKET_SIZE);
+
+            // Start listening for responses
+            _tcp.ReceiveAsync(e);
+
+            // Wait for successful authentication
+            _authenticationTask = new TaskCompletionSource<bool>();
+            await SendPacketAsync(new RCONPacket(0, PacketType.Auth, _password));
+            await _authenticationTask.Task;
+
+            //Don't watch
+            //Task.Run(() => WatchForDisconnection(_reconnectDelay)).Forget();
+        }
+
+        /// <summary>
+        ///     Send a command to the server, and wait for the response before proceeding.  Expect the result to be parseable into
+        ///     T.
+        /// </summary>
+        /// <typeparam name="T">Type to parse the command as.</typeparam>
+        /// <param name="command">Command to send to the server.</param>
+        public async Task<T> SendCommandAsync<T>(string command)
+            where T : class, IParseable, new()
+        {
+            Monitor.Enter(_lock);
+            var source = new TaskCompletionSource<T>();
+            var instance = ParserHelpers.CreateParser<T>();
+
+            var container = new ParserContainer
+            {
+                IsMatch = line => instance.IsMatch(line),
+                Parse = line => instance.Parse(line),
+                Callback = parsed => source.SetResult((T) parsed)
+            };
+
+            _pendingCommands.Add(++_packetId, container.TryCallback);
+            var packet = new RCONPacket(_packetId, PacketType.ExecCommand, command);
+            Monitor.Exit(_lock);
+
+            await SendPacketAsync(packet);
+            return await source.Task;
+        }
+
+        public async Task<string> SendCommandOrRetry(string command)
+        {
+            if (!_tcp.Connected)
+                try
+                {
+                   
+                    await ConnectAsync();
+                }
+                catch
+                {
+                    Dispose();
+                    Log($"Failed to reconnect the TCP Socket for `{_endpoint}`. Client will be " +
+                        $"recreated next RCON attempt.");
+                    return "Failed to connect to RCON server, please try again.";
+                }
+
+            try
+            {
+                return await SendCommandAsync(command);
+            }
+            catch
+            {
+                Log($"Failed to send command to `{_endpoint}`, will attempt reconnect before trying again.");
+            }
+
+            try
+            {
+                await ConnectAsync();
+                return await SendCommandAsync(command);
+            }
+            catch
+            {
+                Dispose();
+                Log($"Failed to send command to `{_endpoint}` after 2 retries. Is the RCON server running?");
+                return "Failed to connect to RCON server after 2 retries, please try again later.";
+            }
+        }
+
+        /// <summary>
+        ///     Send a command to the server, and wait for the response before proceeding.  R
+        /// </summary>
+        /// <param name="command">Command to send to the server.</param>
+        public async Task<string> SendCommandAsync(string command)
+        {
+            Monitor.Enter(_lock);
+            var source = new TaskCompletionSource<string>();
+            _pendingCommands.Add(++_packetId, source.SetResult);
+            var packet = new RCONPacket(_packetId, PacketType.ExecCommand, command);
+            Monitor.Exit(_lock);
+
+            await SendPacketAsync(packet);
+            return await source.Task;
+        }
+
+        private void RCONPacketReceived(RCONPacket packet)
+        {
+            // Call pending result and remove from map
+            Action<string> action;
+            if (_pendingCommands.TryGetValue(packet.Id, out action))
+            {
+                action?.Invoke(packet.Body);
+                _pendingCommands.Remove(packet.Id);
+            }
+        }
+
+        /// <summary>
+        ///     Send a packet to the server.
+        /// </summary>
+        /// <param name="packet">Packet to send, which will be serialized.</param>
+        private async Task SendPacketAsync(RCONPacket packet)
+        {
+            if (!_connected) throw new InvalidOperationException("Connection is closed.");
+            await _tcp.SendAsync(new ArraySegment<byte>(packet.ToBytes()), SocketFlags.None);
+        }
+
+        /// <summary>
+        ///     Event called whenever raw data is received on the TCP socket.
+        /// </summary>
+        private void TCPPacketReceived(object sender, SocketAsyncEventArgs e)
+        {
+            // Parse out the actual RCON packet
+            var packet = RCONPacket.FromBytes(e.Buffer);
+
+            if (packet.Type == PacketType.AuthResponse)
+            {
+                // Failed auth responses return with an ID of -1
+                if (packet.Id == -1)
+                    throw new AuthenticationException($"Authentication failed for {_tcp.RemoteEndPoint}.");
+
+                // Tell Connect that authentication succeeded
+                _authenticationTask.SetResult(true);
+            }
+
+            // Forward to handler
+            RCONPacketReceived(packet);
+
+            // Continue listening
+            if (!_connected) return;
+            _tcp.ReceiveAsync(e);
+        }
+
+        /// <summary>
+        ///     Polls the server to check if RCON is still authenticated.  Will still throw if the password was changed elsewhere.
+        /// </summary>
+        /// <param name="delay">Time in milliseconds to wait between polls.</param>
+        private async void WatchForDisconnection(uint delay)
+        {
+            var checkedDelay = checked((int) delay);
+
+            while (true)
+            {
+                try
+                {
+                    Identifier = Guid.NewGuid().ToString().Substring(0, 5);
+                    await SendCommandAsync(Constants.CHECK_STR + Identifier);
+                }
+                catch
+                {
+                    Dispose();
+                    return;
+                }
+
+                await Task.Delay(checkedDelay);
+            }
+        }
+    }
+}

--- a/CoreRCON/ServerQuery.cs
+++ b/CoreRCON/ServerQuery.cs
@@ -1,0 +1,125 @@
+﻿using CoreRCON.PacketFormats;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CoreRCON
+{
+    /// <summary>
+    /// Make a request to a server following the Source and Minecraft Server Query format.
+    /// </summary>
+    /// <see cref="https://developer.valvesoftware.com/wiki/Server_queries"/>
+    /// <see cref="http://wiki.vg/Query"/>
+    public class ServerQuery
+	{
+        /// <summary>
+        /// The different query implementations.
+        /// </summary>
+        public enum ServerType {
+            Source,
+            Minecraft
+        }
+
+        /// <summary>
+        /// Minecraft packet types.
+        /// </summary>
+        private enum PacketType
+        {
+            Handshake = 0x09,
+            Stat = 0x00
+        }
+
+		private static UdpClient _client;
+        private static readonly byte[] _magic = new byte[] { 0xFE, 0xFD }; // Minecraft 'magic' bytes.
+        private static readonly byte[] _sessionid = new byte[] { 0x01, 0x02, 0x03, 0x04 };
+
+        static ServerQuery()
+		{
+			_client = new UdpClient();
+		}
+
+		/// <summary>
+		/// Get information about the server.
+		/// </summary>
+		/// <param name="address">IP of the server.</param>
+		/// <param name="port">Port to query gameserver.</param>
+        /// <param name="type">Server type.</param>
+		public static async Task<IQueryInfo> Info(IPAddress address, ushort port, ServerType type) => await Info(new IPEndPoint(address, port), type);
+
+		/// <summary>
+		/// Get information about the server.
+		/// </summary>
+		/// <param name="host">Endpoint of the server.</param>
+		public static async Task<IQueryInfo> Info(IPEndPoint host, ServerType type)
+		{
+            switch (type)
+            {
+                case ServerType.Source:
+                    await _client.SendAsync(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0x54, 0x53, 0x6F, 0x75, 0x72, 0x63, 0x65, 0x20, 0x45, 0x6E, 0x67, 0x69, 0x6E, 0x65, 0x20, 0x51, 0x75, 0x65, 0x72, 0x79, 0x00 }, 25, host);
+                    var sourceResponse = await _client.ReceiveAsync();
+                    return SourceQueryInfo.FromBytes(sourceResponse.Buffer);
+                case ServerType.Minecraft:
+                    var padding = new byte[] { 0x00, 0x00, 0x00, 0x00 };
+                    var datagram = _magic.Concat(new[] { (byte)PacketType.Stat }).Concat(_sessionid).Concat(await Challenge(host, ServerType.Minecraft)).Concat(padding).ToArray();
+                    await _client.SendAsync(datagram, datagram.Length, host);
+                    var mcResponce = await _client.ReceiveAsync();
+                    return MinecraftQueryInfo.FromBytes(mcResponce.Buffer);
+                default:
+                    throw new ArgumentException("type argument was invalid");
+            }
+			
+		}
+
+		/// <summary>
+		/// Get information about each player currently on the server.
+		/// </summary>
+		/// <param name="address">IP of the server.</param>
+		/// <param name="port">Port to query gameserver.</param>
+		public static async Task<ServerQueryPlayer[]> Players(IPAddress address, ushort port) => await Players(new IPEndPoint(address, port));
+
+		/// <summary>
+		/// Get information about each player currently on the server.
+		/// </summary>
+		/// <param name="host">Endpoint of the server.</param>
+		public static async Task<ServerQueryPlayer[]> Players(IPEndPoint host)
+		{
+			var challenge = new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0x55 }.Concat(await Challenge(host, ServerType.Source)).ToArray();
+			await _client.SendAsync(challenge, 9, host);
+			var response = await _client.ReceiveAsync();
+			return ServerQueryPlayer.FromBytes(response.Buffer);
+		}
+
+		/// <summary>
+		/// Send a challenge request to the server and receive a code.
+		/// </summary>
+		/// <param name="host">Endpoint of the server.</param>
+		/// <returns>Challenge code to use with challenged requests.</returns>
+		private static async Task<byte[]> Challenge(IPEndPoint host, ServerType type)
+		{
+            switch (type)
+            {
+                case ServerType.Source:
+                    await _client.SendAsync(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0x55, 0xFF, 0xFF, 0xFF, 0xFF }, 9, host);
+                    return (await _client.ReceiveAsync()).Buffer.Skip(5).Take(4).ToArray();
+                case ServerType.Minecraft:
+                    // Create request
+                    var datagram = _magic.Concat(new[] { (byte)PacketType.Handshake }).Concat(_sessionid).ToArray();
+                    await _client.SendAsync(datagram, datagram.Length, host);
+
+                    // Parse challenge token
+                    var buffer = (await _client.ReceiveAsync()).Buffer;
+                    var challangeBytes = new byte[16];
+                    Array.Copy(buffer, 5, challangeBytes, 0, buffer.Length - 5);
+                    var challengeInt = int.Parse(Encoding.ASCII.GetString(challangeBytes));
+                    return BitConverter.GetBytes(challengeInt).Reverse().ToArray();
+                default:
+                    throw new ArgumentException("type argument was invalid");
+            }
+            
+		}
+	}
+}

--- a/RCONServerLib/RemoteConClient.cs
+++ b/RCONServerLib/RemoteConClient.cs
@@ -41,12 +41,12 @@ namespace RCONServerLib
         /// <summary>
         ///     The TCP Client
         /// </summary>
-        private readonly TcpClient _client;
+        private TcpClient _client;
 
         /// <summary>
         ///     A list containing all requested commands for event handling
         /// </summary>
-        private readonly Dictionary<int, CommandResult> _requestedCommands;
+        private Dictionary<int, CommandResult> _requestedCommands;
 
         /// <summary>
         ///     A buffer containing the packet
@@ -71,7 +71,6 @@ namespace RCONServerLib
         public RemoteConClient()
         {
             _client = new TcpClient();
-
             _packetId = 0;
             _requestedCommands = new Dictionary<int, CommandResult>();
         }
@@ -148,6 +147,7 @@ namespace RCONServerLib
         /// </summary>
         public void Disconnect()
         {
+            Console.WriteLine("In Disconnect Method.");
             if (_client.Connected)
             {
                 _client.Client.Disconnect(false);
@@ -279,7 +279,7 @@ namespace RCONServerLib
                             Log("Authentication success.");
                             Authenticated = true;
                             if (OnAuthResult != null)
-                                OnAuthResult(false);
+                                OnAuthResult(true);
                         }
 
                     return;


### PR DESCRIPTION
CoreRCON has TAP abilities and allows for listening to server messages.

Added Start and Stop listening to allow for ingame logging of feedback and rcon messages. This auto starts for playtest events. The feedback is sent when the playtest completes.

Client downloads all users to fix a mention bug.

Rcon moved to its own service, and has better handling of connections.

A bunch of other good stuff

Resolved #4 and #7 